### PR TITLE
fix(frontend): fix big skill icons on mobile

### DIFF
--- a/src/components/SkillItem.module.scss
+++ b/src/components/SkillItem.module.scss
@@ -11,12 +11,6 @@
 
 .bg {
   padding: 5px;
-
-  > svg {
-    fill: #fff !important;
-    height: 100%;
-    width: 100%;
-  }
 }
 
 .flex {

--- a/src/components/SkillItem.tsx
+++ b/src/components/SkillItem.tsx
@@ -12,6 +12,7 @@ const SkillItem = ({ icon, text, testId }: Props) => {
     <li>
       <span className={styles.bg} data-testid={testId}>
         {icon({
+          size: 30,
           className: styles.skillIcon,
           fill: '#fff',
         })}


### PR DESCRIPTION
Fixes wrong styling being applied due to height and width of react-icon svg being set to 100%. This caused the icons on mobile to be massive and they would take up the majority of the screen