### PR TITLE
feat(frontend): always show hash prefix on tags

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -394,8 +394,7 @@ button {
 
 .hash-tag::before {
   content: '#';
-  opacity: 0;
-  transition: opacity 150ms ease;
+  opacity: 0.6;
 }
 
 a.hash-tag {
@@ -407,19 +406,8 @@ a.hash-tag::after {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  article:hover .hash-tag::before,
-  .hash-tag:hover::before {
-    opacity: 0.6;
-  }
-
   a.hash-tag:hover {
     color: var(--link-color);
-  }
-}
-
-@media (hover: none) {
-  .hash-tag::before {
-    opacity: 0.6;
   }
 }
 


### PR DESCRIPTION
Removes the hover-reveal behavior on tag hash prefixes so the `#` is always visible on blog/portfolio card tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)