### PR TITLE
feat(frontend): add /tracks page

### DIFF
--- a/e2e/tracks.spec.ts
+++ b/e2e/tracks.spec.ts
@@ -1,0 +1,34 @@
+import { expect, type Page, test } from '@playwright/test';
+import { baseUrl } from './config/baseUrl';
+
+let page: Page;
+
+test.describe('tracks', () => {
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto(`${baseUrl}/tracks`);
+  });
+
+  test('renders the page heading and sections', async () => {
+    await expect(page.getByTestId('page-title')).toHaveText('Tracks');
+    await expect(
+      page.getByRole('heading', { name: 'Recently played' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Top tracks' }),
+    ).toBeVisible();
+  });
+
+  test('exposes the top tracks time-range controls', async () => {
+    const group = page.getByRole('group', { name: 'Time range' });
+    await expect(group.getByRole('button', { name: '4 weeks' })).toBeVisible();
+    await expect(group.getByRole('button', { name: '6 months' })).toBeVisible();
+    await expect(group.getByRole('button', { name: 'All time' })).toBeVisible();
+  });
+
+  test('is reachable from the header navigation', async () => {
+    await page.goto(baseUrl);
+    await page.getByRole('link', { name: 'Tracks' }).first().click();
+    await expect(page).toHaveURL(/\/tracks\/?$/);
+  });
+});

--- a/src/components/ui/Header.astro
+++ b/src/components/ui/Header.astro
@@ -45,6 +45,10 @@ const navItems: NavItem[] = [
     name: 'Blog',
     path: '/blog',
   },
+  {
+    name: 'Tracks',
+    path: '/tracks',
+  },
 ];
 
 const commandNavItems: NavItem[] = [

--- a/src/components/ui/RecentTracks.tsx
+++ b/src/components/ui/RecentTracks.tsx
@@ -1,0 +1,142 @@
+import { formatDistanceToNowStrict } from 'date-fns';
+import React, { useEffect, useState } from 'react';
+import spotifyService from '../../services/spotifyService';
+import type { RecentTrack } from '../../types/spotify';
+import styles from './Tracks.module.css';
+
+const POLL_MS = 30_000;
+const LIMIT = 10;
+
+const SKELETON_KEYS = Array.from({ length: 5 }, (_, index) => `row-${index}`);
+
+function EqualiserBars() {
+  return (
+    <span className={styles.bars} aria-hidden>
+      <span />
+      <span />
+      <span />
+    </span>
+  );
+}
+
+function playedLabel(track: RecentTrack): string {
+  if (track.nowPlaying) {
+    return 'Now playing';
+  }
+
+  if (track.playedAt) {
+    return formatDistanceToNowStrict(new Date(track.playedAt * 1000), {
+      addSuffix: true,
+    });
+  }
+
+  return '';
+}
+
+function trackKey(track: RecentTrack): string {
+  return `${track.songUrl || track.title}-${track.nowPlaying ? 'now' : track.playedAt}`;
+}
+
+export default function RecentTracks() {
+  const [tracks, setTracks] = useState<RecentTrack[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        const response = await spotifyService.recentTracks(LIMIT);
+        if (active) {
+          setTracks(response.tracks);
+          setFailed(false);
+        }
+      } catch {
+        if (active) {
+          setFailed(true);
+        }
+      }
+    };
+
+    load();
+    const intervalId = window.setInterval(load, POLL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  if (failed && !tracks) {
+    return (
+      <p className={styles.status} role="status">
+        Could not load recent tracks right now.
+      </p>
+    );
+  }
+
+  if (!tracks) {
+    return (
+      <ul className={styles.list} aria-hidden>
+        {SKELETON_KEYS.map(key => (
+          <li
+            key={key}
+            className={`${styles.skeleton} ${styles.skeletonRow}`}
+          />
+        ))}
+      </ul>
+    );
+  }
+
+  if (tracks.length === 0) {
+    return (
+      <p className={styles.status} role="status">
+        No recent tracks to show.
+      </p>
+    );
+  }
+
+  return (
+    <ul className={styles.list} data-testid="recent-tracks">
+      {tracks.map(track => {
+        const label = playedLabel(track);
+
+        return (
+          <li key={trackKey(track)}>
+            <a
+              className={styles.track}
+              href={track.songUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {track.albumImageUrl ? (
+                <img
+                  className={styles.cover}
+                  src={track.albumImageUrl}
+                  alt=""
+                  width={48}
+                  height={48}
+                  loading="lazy"
+                />
+              ) : (
+                <span className={styles.cover} aria-hidden />
+              )}
+              <span className={styles.trackBody}>
+                <span className={styles.trackTitle}>{track.title}</span>
+                <span className={styles.trackArtist}>{track.artist}</span>
+              </span>
+              {track.nowPlaying ? (
+                <span className={`${styles.trackMeta} ${styles.nowPlaying}`}>
+                  <EqualiserBars />
+                  {label}
+                </span>
+              ) : (
+                label && <span className={styles.trackMeta}>{label}</span>
+              )}
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/ui/TopTracks.tsx
+++ b/src/components/ui/TopTracks.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import spotifyService from '../../services/spotifyService';
+import type { TopTrack, TopTracksTimeRange } from '../../types/spotify';
+import styles from './Tracks.module.css';
+
+const LIMIT = 12;
+
+const SKELETON_KEYS = Array.from(
+  { length: LIMIT },
+  (_, index) => `card-${index}`,
+);
+
+const RANGES: { value: TopTracksTimeRange; label: string }[] = [
+  { value: 'short_term', label: '4 weeks' },
+  { value: 'medium_term', label: '6 months' },
+  { value: 'long_term', label: 'All time' },
+];
+
+interface State {
+  range: TopTracksTimeRange;
+  tracks: TopTrack[] | null;
+  failed: boolean;
+}
+
+export default function TopTracks() {
+  const [range, setRange] = useState<TopTracksTimeRange>('medium_term');
+  const [state, setState] = useState<State>({
+    range: 'medium_term',
+    tracks: null,
+    failed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    spotifyService
+      .topTracks(range, LIMIT)
+      .then(response => {
+        if (active) {
+          setState({ range, tracks: response.tracks, failed: false });
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setState({ range, tracks: null, failed: true });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [range]);
+
+  const settled = state.range === range;
+  const tracks = settled ? state.tracks : null;
+  const failed = settled && state.failed;
+
+  let content: React.ReactNode;
+
+  if (failed) {
+    content = (
+      <p className={styles.status} role="status">
+        Could not load top tracks right now.
+      </p>
+    );
+  } else if (!tracks) {
+    content = (
+      <ul className={styles.grid} aria-hidden>
+        {SKELETON_KEYS.map(key => (
+          <li
+            key={key}
+            className={`${styles.skeleton} ${styles.skeletonCard}`}
+          />
+        ))}
+      </ul>
+    );
+  } else if (tracks.length === 0) {
+    content = (
+      <p className={styles.status} role="status">
+        No top tracks to show.
+      </p>
+    );
+  } else {
+    content = (
+      <ul className={styles.grid} data-testid="top-tracks">
+        {tracks.map((track, index) => (
+          <li key={`${track.title}-${track.artist}`}>
+            <a
+              className={styles.card}
+              href={track.songUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className={styles.cardCoverWrap}>
+                {track.albumImageUrl && (
+                  <img
+                    className={styles.cardCover}
+                    src={track.albumImageUrl}
+                    alt=""
+                    loading="lazy"
+                  />
+                )}
+                <span className={styles.cardRank}>{index + 1}</span>
+              </span>
+              <span className={styles.cardTitle}>{track.title}</span>
+              <span className={styles.cardArtist}>{track.artist}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <div>
+      <div className={styles.ranges} role="group" aria-label="Time range">
+        {RANGES.map(option => (
+          <button
+            key={option.value}
+            type="button"
+            className={styles.rangeButton}
+            aria-pressed={range === option.value}
+            onClick={() => setRange(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      {content}
+    </div>
+  );
+}

--- a/src/components/ui/Tracks.module.css
+++ b/src/components/ui/Tracks.module.css
@@ -1,0 +1,337 @@
+.section {
+  padding: 1.5rem 0 2.5rem;
+  border-top: 2px solid rgba(255, 255, 255, 0.08);
+}
+
+.sectionHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.sectionMeta {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+/* Time-range toggle */
+.ranges {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.rangeButton {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    color var(--transition-base),
+    background var(--transition-base),
+    border-color var(--transition-base);
+}
+
+.rangeButton:hover {
+  color: var(--text-color);
+}
+
+.rangeButton[aria-pressed='true'] {
+  color: var(--text-color);
+  background: rgba(var(--accent-rgb), 0.12);
+  border-color: rgba(var(--accent-rgb), 0.25);
+}
+
+.rangeButton:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--bg-color),
+    0 0 0 4px rgba(var(--accent-rgb), 0.45);
+}
+
+/* Recent tracks list */
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.track {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.7rem;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid transparent;
+  transition:
+    background var(--transition-base),
+    border-color var(--transition-base);
+}
+
+.track:hover {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.07);
+}
+
+.track:focus-visible {
+  outline: none;
+  border-color: rgba(var(--accent-rgb), 0.35);
+  background: rgba(var(--accent-rgb), 0.08);
+}
+
+.cover {
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 8px;
+  object-fit: cover;
+  background: var(--bg-color-muted);
+}
+
+.trackBody {
+  min-width: 0;
+  flex: 1;
+}
+
+.trackTitle {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trackArtist {
+  margin: 0.1rem 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trackMeta {
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.nowPlaying {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #6ee7b7;
+  font-weight: 500;
+}
+
+/* Now-playing equaliser bars */
+.bars {
+  display: inline-flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+}
+
+.bars span {
+  width: 3px;
+  border-radius: 3px;
+  background-color: #1bd760;
+  transform-origin: bottom;
+  animation: tracksBar 1.1s ease-in-out infinite alternate;
+}
+
+.bars span:nth-child(1) {
+  height: 45%;
+  animation-delay: 0s;
+}
+
+.bars span:nth-child(2) {
+  height: 70%;
+  animation-delay: -0.35s;
+}
+
+.bars span:nth-child(3) {
+  height: 55%;
+  animation-delay: -0.65s;
+}
+
+@keyframes tracksBar {
+  10% {
+    transform: scaleY(0.35);
+  }
+  30% {
+    transform: scaleY(1);
+  }
+  60% {
+    transform: scaleY(0.5);
+  }
+  80% {
+    transform: scaleY(0.78);
+  }
+  100% {
+    transform: scaleY(0.55);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bars span {
+    animation: none;
+  }
+}
+
+/* Top tracks grid */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.cardCoverWrap {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: var(--bg-color-muted);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.cardCover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--transition-base);
+}
+
+.card:hover .cardCover {
+  transform: scale(1.04);
+}
+
+.cardRank {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(6, 8, 12, 0.72);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.cardTitle {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card:hover .cardTitle {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.cardArtist {
+  margin: -0.3rem 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* States */
+.status {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.skeleton {
+  border-radius: 0.7rem;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.08),
+    rgba(255, 255, 255, 0.04)
+  );
+  background-size: 200% 100%;
+  animation: tracksShimmer 1.4s ease-in-out infinite;
+}
+
+.skeletonRow {
+  height: 3.9rem;
+}
+
+.skeletonCard {
+  aspect-ratio: 1 / 1;
+}
+
+@keyframes tracksShimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  }
+}

--- a/src/components/ui/__tests__/RecentTracks.test.tsx
+++ b/src/components/ui/__tests__/RecentTracks.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import RecentTracks from '../RecentTracks';
+
+const { mockRecentTracks } = vi.hoisted(() => ({
+  mockRecentTracks: vi.fn(),
+}));
+
+vi.mock('../../../services/spotifyService', () => ({
+  default: {
+    recentTracks: mockRecentTracks,
+  },
+}));
+
+describe('RecentTracks', () => {
+  beforeEach(() => {
+    mockRecentTracks.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders a now-playing track and historical scrobbles', async () => {
+    mockRecentTracks.mockResolvedValue({
+      tracks: [
+        {
+          title: 'Live song',
+          artist: 'Live artist',
+          album: 'Live album',
+          albumImageUrl: 'https://example.com/live.jpg',
+          songUrl: 'https://last.fm/live',
+          nowPlaying: true,
+          playedAt: null,
+        },
+        {
+          title: 'Old song',
+          artist: 'Old artist',
+          album: 'Old album',
+          albumImageUrl: 'https://example.com/old.jpg',
+          songUrl: 'https://last.fm/old',
+          nowPlaying: false,
+          playedAt: Math.floor(Date.now() / 1000) - 3600,
+        },
+      ],
+    });
+
+    render(<RecentTracks />);
+
+    expect(await screen.findByText('Live song')).toBeInTheDocument();
+    expect(screen.getByText('Now playing')).toBeInTheDocument();
+    expect(screen.getByText('Old song')).toBeInTheDocument();
+    expect(screen.getByText(/ago$/)).toBeInTheDocument();
+  });
+
+  test('shows an error state when the request fails', async () => {
+    mockRecentTracks.mockRejectedValue(new Error('boom'));
+
+    render(<RecentTracks />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Could not load recent tracks right now.'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/__tests__/TopTracks.test.tsx
+++ b/src/components/ui/__tests__/TopTracks.test.tsx
@@ -1,0 +1,65 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import TopTracks from '../TopTracks';
+
+const { mockTopTracks } = vi.hoisted(() => ({
+  mockTopTracks: vi.fn(),
+}));
+
+vi.mock('../../../services/spotifyService', () => ({
+  default: {
+    topTracks: mockTopTracks,
+  },
+}));
+
+function trackFixture(title: string) {
+  return {
+    title,
+    artist: `${title} artist`,
+    album: `${title} album`,
+    albumImageUrl: `https://example.com/${title}.jpg`,
+    songUrl: `https://open.spotify.com/${title}`,
+  };
+}
+
+describe('TopTracks', () => {
+  beforeEach(() => {
+    mockTopTracks.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('loads the default medium_term range on mount', async () => {
+    mockTopTracks.mockResolvedValue({ tracks: [trackFixture('Alpha')] });
+
+    render(<TopTracks />);
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    expect(mockTopTracks).toHaveBeenCalledWith('medium_term', 12);
+  });
+
+  test('refetches when a different time range is selected', async () => {
+    mockTopTracks
+      .mockResolvedValueOnce({ tracks: [trackFixture('Alpha')] })
+      .mockResolvedValueOnce({ tracks: [trackFixture('Beta')] });
+
+    render(<TopTracks />);
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'All time' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Beta')).toBeInTheDocument();
+    });
+    expect(mockTopTracks).toHaveBeenLastCalledWith('long_term', 12);
+  });
+});

--- a/src/pages/tracks.astro
+++ b/src/pages/tracks.astro
@@ -1,0 +1,110 @@
+---
+import Hero from '../components/Hero.astro';
+import BaseLayout from '../components/layout/BaseLayout.astro';
+import Container from '../components/ui/Container.astro';
+import RecentTracks from '../components/ui/RecentTracks.tsx';
+import TopTracks from '../components/ui/TopTracks.tsx';
+import { siteConfig } from '../config/site';
+
+const title = `Tracks | ${siteConfig.authorName}`;
+const description =
+  'What Luke Howsam has been listening to lately - recently played tracks from Last.fm and top tracks from Spotify.';
+const structuredData = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: title,
+    url: `${siteConfig.siteUrl}/tracks/`,
+    description,
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: siteConfig.siteUrl,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Tracks',
+        item: `${siteConfig.siteUrl}/tracks/`,
+      },
+    ],
+  },
+];
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  structuredData={structuredData}
+>
+  <Container class="tracks-container">
+    <Hero title="Tracks" description="What I've been listening to lately" />
+
+    <section class="tracks-section" aria-labelledby="recently-played">
+      <div class="tracks-section__head">
+        <h2 id="recently-played" class="tracks-section__title">
+          Recently played
+        </h2>
+        <p class="tracks-section__meta">Live from Last.fm</p>
+      </div>
+      <RecentTracks client:load />
+    </section>
+
+    <section class="tracks-section" aria-labelledby="top-tracks-heading">
+      <div class="tracks-section__head">
+        <h2 id="top-tracks-heading" class="tracks-section__title">
+          Top tracks
+        </h2>
+        <p class="tracks-section__meta">From Spotify</p>
+      </div>
+      <TopTracks client:load />
+    </section>
+  </Container>
+</BaseLayout>
+
+<style>
+  .tracks-container {
+    max-width: none;
+    margin: 0 auto;
+  }
+
+  .tracks-section {
+    padding: 1.5rem 0 2.5rem;
+    border-top: 2px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .tracks-section__head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .tracks-section__title {
+    margin: 0;
+    font-family: var(--font-primary);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  .tracks-section__meta {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 640px) {
+    .tracks-section {
+      padding-bottom: 2rem;
+    }
+  }
+</style>

--- a/src/services/spotifyService.ts
+++ b/src/services/spotifyService.ts
@@ -1,4 +1,9 @@
-import type { Song } from '../types/spotify';
+import type {
+  RecentTracksResponse,
+  Song,
+  TopTracksResponse,
+  TopTracksTimeRange,
+} from '../types/spotify';
 
 function getConsumer(): string {
   const baseUrl = import.meta.env.PUBLIC_BASE_URL;
@@ -24,22 +29,39 @@ function getConsumer(): string {
   }
 }
 
+async function request<T>(path: string): Promise<T> {
+  const baseUrl = import.meta.env.PUBLIC_NOW_PLAYING_API_BASE_URL;
+  const key = import.meta.env.PUBLIC_NOW_PLAYING_API_KEY;
+  const consumer = getConsumer();
+  const response = await fetch(`${String(baseUrl).replace(/\/$/, '')}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-consumer': consumer,
+      'x-api-key': key ?? '',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request to ${path} failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
 const spotifyService = {
-  async lambdaNowPlaying(): Promise<Song> {
-    const baseUrl = import.meta.env.PUBLIC_NOW_PLAYING_API_BASE_URL;
-    const key = import.meta.env.PUBLIC_NOW_PLAYING_API_KEY;
-    const consumer = getConsumer();
-    const response = await fetch(
-      `${String(baseUrl).replace(/\/$/, '')}/api/now-playing`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          'x-consumer': consumer,
-          'x-api-key': key ?? '',
-        },
-      },
+  lambdaNowPlaying(): Promise<Song> {
+    return request<Song>('/api/now-playing');
+  },
+  recentTracks(limit = 10): Promise<RecentTracksResponse> {
+    return request<RecentTracksResponse>(`/api/recent-tracks?limit=${limit}`);
+  },
+  topTracks(
+    timeRange: TopTracksTimeRange = 'medium_term',
+    limit = 12,
+  ): Promise<TopTracksResponse> {
+    return request<TopTracksResponse>(
+      `/api/top-tracks?time_range=${timeRange}&limit=${limit}`,
     );
-    return response.json() as Promise<Song>;
   },
 };
 

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -6,6 +6,34 @@ export interface Song {
   songUrl?: string;
 }
 
+export interface RecentTrack {
+  title: string;
+  artist: string;
+  album: string;
+  albumImageUrl: string;
+  songUrl: string;
+  nowPlaying: boolean;
+  playedAt: number | null;
+}
+
+export interface RecentTracksResponse {
+  tracks: RecentTrack[];
+}
+
+export interface TopTrack {
+  title: string;
+  artist: string;
+  album: string;
+  albumImageUrl: string;
+  songUrl: string;
+}
+
+export interface TopTracksResponse {
+  tracks: TopTrack[];
+}
+
+export type TopTracksTimeRange = 'short_term' | 'medium_term' | 'long_term';
+
 export interface Artist {
   external_urls: {
     spotify: string;


### PR DESCRIPTION
Adds a `/tracks` page for current + recent music.

## What
- **Recently played** section - live from Last.fm, polls every 30s, shows a now-playing row with animated bars plus relative "x ago" timestamps for scrobbles
- **Top tracks** section - from Spotify, with a 4 weeks / 6 months / All time range toggle
- Tracks nav link in the header (and command menu)

## Notes
- Backed by a new `/api/recent-tracks` endpoint in lho-lambda (separate PR) - until that ships the page shows its empty/error states
- Added component unit tests + an e2e spec

prettier / eslint / tsc / vitest / build all pass.